### PR TITLE
Add GLM data journalism example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ AZURE_DEPLOYMENT_NAME=gpt-4.1
 TOGETHER_AI_API_KEY=your-together-ai-api-key-here-to-do-image-gen
 TAVILY_API_KEY=your-tavily-api-key-here-to-do-websearch-when-deep-research
 HUGGINGFACE_TOKEN=your-huggingface-token-here
+GLM_API_KEY=your-glm-api-key-here
+GLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ see example_browser_use.py
 see example_with_managed_agents.py
 see example_deep_research.py
 see example_reason.py
+see example_data_journalism.py
 
 ## Configuration
 

--- a/example_data_journalism.py
+++ b/example_data_journalism.py
@@ -1,0 +1,76 @@
+import asyncio
+import os
+from dotenv import load_dotenv
+import pandas as pd
+import matplotlib.pyplot as plt
+from openai import AsyncOpenAI
+from minion_agent.tools.generation import save_and_generate_html
+
+load_dotenv()
+
+GLM_API_KEY = os.getenv("GLM_API_KEY")
+GLM_BASE_URL = os.getenv("GLM_BASE_URL", "https://open.bigmodel.cn/api/paas/v4")
+MODEL_ID = "GLM-4-PLUS"
+
+client = AsyncOpenAI(api_key=GLM_API_KEY, base_url=GLM_BASE_URL)
+
+def create_charts(df):
+    paths = []
+    latest = df[df['date'] == df['date'].max()]
+    top10 = latest.nlargest(10, 'total_vaccinations')
+    plt.figure(figsize=(10,6))
+    plt.bar(top10['location'], top10['total_vaccinations'])
+    plt.xticks(rotation=45, ha='right')
+    plt.title('Top 10 Countries by Total Vaccinations')
+    path1 = 'chart1.svg'
+    plt.savefig(path1, format='svg', bbox_inches='tight')
+    paths.append(path1)
+    plt.close()
+
+    subset = df[df['location'].isin(['China', 'United States'])]
+    pivot = subset.pivot(index='date', columns='location', values='total_vaccinations').dropna()
+    pivot.plot(figsize=(10,6))
+    plt.title('Vaccination Progress: China vs US')
+    path2 = 'chart2.svg'
+    plt.savefig(path2, format='svg', bbox_inches='tight')
+    paths.append(path2)
+    plt.close()
+
+    boosters = latest.nlargest(10, 'total_boosters')
+    plt.figure(figsize=(10,6))
+    plt.bar(boosters['location'], boosters['total_boosters'])
+    plt.xticks(rotation=45, ha='right')
+    plt.title('Top 10 Countries by Booster Shots')
+    path3 = 'chart3.svg'
+    plt.savefig(path3, format='svg', bbox_inches='tight')
+    paths.append(path3)
+    plt.close()
+
+    return paths
+
+async def chat(prompt: str) -> str:
+    resp = await client.chat.completions.create(model=MODEL_ID, messages=[{"role": "user", "content": prompt}])
+    return resp.choices[0].message.content.strip()
+
+async def main():
+    topic = "全球疫苗接种现状"
+    plan_prompt = f"你是一名数据新闻策划师，为主题'{topic}'提供3个报道角度，并解释理由。"
+    plan = await chat(plan_prompt)
+    print('计划建议:\n', plan)
+
+    url = "https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/vaccinations/vaccinations.csv"
+    df = pd.read_csv(url)
+    chart_paths = create_charts(df)
+
+    analysis_summary = "已根据公开数据生成3个图表：" + ", ".join(chart_paths)
+    story_prompt = (
+        f"你是一名数据新闻撰稿人，请根据以下分析结果撰写一篇中文数据新闻文章，文章中需引用图表文件名：{', '.join(chart_paths)}。\n"
+        f"分析结果：{analysis_summary}"
+    )
+    article_md = await chat(story_prompt)
+
+    html = save_and_generate_html(article_md, filename='data_journalism_story.html', title=topic)
+    print('HTML 已保存为 data_journalism_story.html')
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,8 @@ nest-asyncio>=1.5.6
 sqlalchemy>=2.0.0
 aiosqlite>=0.17.0
 
-browser-use
-loguru
+browser-use>=0.0.1
+loguru>=0.7.2
+pandas>=1.5.0
+matplotlib>=3.8.0
+openai>=1.75.0


### PR DESCRIPTION
## Summary
- support GLM base url & API key in `.env.example`
- document new `example_data_journalism.py`
- add GLM-based data journalism example producing charts and HTML
- update runtime requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: tests_tool_calling_agent_integration, tests_smolagents_tools, test_calculate_tool)*

------
https://chatgpt.com/codex/tasks/task_e_6848235e63d8832283b0ac48e667bca5